### PR TITLE
Rework CI to be granular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
       - run: make npm.install
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,9 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - run: |
-          false
-          true
-
+          for i in true false; do
+            sh -c "$i"
+          done
 
       - run: make docker.image no-cache=yes
                   platform=${{ matrix.os }}/${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches: ["master"]
-    tags: ["alpine*"]
+    #tags: ["alpine*"]
+    tags: ["*"]
   pull_request:
     branches: ["master"]
   schedule:
@@ -33,26 +34,16 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
-      - run: |
-          for i in true \
-                   false \
-                   true
-          do
-            echo "$i"
-            sh -c "$i"
-          done
-
       - run: make docker.image no-cache=yes
                   platform=${{ matrix.os }}/${{ matrix.arch }}
                   tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
 
-      - run: make docker.tar
-                  to-file=.cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+      - run: make docker.tar to-file=.cache/image.tar
                   tags=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
-          path: .cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+          path: .cache/image.tar
           retention-days: 1
 
 
@@ -79,8 +70,7 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
           path: .cache/
-      - run: make docker.untar
-                  from-file=.cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+      - run: make docker.untar from-file=.cache/image.tar
 
       - run: make test.docker
                   platform=${{ matrix.os }}/${{ matrix.arch }}
@@ -113,6 +103,91 @@ jobs:
                     && secrets.DOCKERHUB_BOT_USER == ''))
              ) }}" >> $GITHUB_OUTPUT
 
+      - uses: actions/checkout@v3
+        if: ${{ steps.skip.outputs.no == 'true' }}
+
+      - name: Parse Docker image name from Git repository name
+        id: image
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.repository }}
+          regex: '^${{ github.repository_owner }}/(.+)-docker-image$'
+      - name: Parse version from Git tag
+        id: version
+        uses: actions-ecosystem/action-regex-match@v2
+        with:
+          text: ${{ github.ref }}
+          regex: '^refs/tags/(.+)$'
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: .cache/
+        if: ${{ steps.skip.outputs.no == 'true' }}
+
+      - name: Login to ${{ matrix.registry }} container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ matrix.registry }}
+          username: ${{ (matrix.registry == 'docker.io'
+                         && secrets.DOCKERHUB_BOT_USER)
+                     || (matrix.registry == 'quay.io'
+                         && secrets.QUAYIO_ROBOT_USER)
+                     || github.repository_owner }}
+          password: ${{ (matrix.registry == 'docker.io'
+                         && secrets.DOCKERHUB_BOT_PASS)
+                     || (matrix.registry == 'quay.io'
+                         && secrets.QUAYIO_ROBOT_TOKEN)
+                     || secrets.GITHUB_TOKEN }}
+        if: ${{ steps.skip.outputs.no == 'true' }}
+
+      - name: Tag and push single-platform images
+        run: |
+          for platform in linux-amd64 \
+                          linux-arm32v6 \
+                          linux-arm32v7 \
+                          linux-arm64v8 \
+                          linux-ppc64le \
+                          linux-s390x
+          do
+            make docker.untar \
+                 from-file=.cache/$platform-${{ github.run_number }}/image.tar
+            make docker.tags \
+                 of=build-${{ github.run_number }}-$platform \
+                 tags=${{ steps.version.outputs.group1 }}-$platform \
+                 registries=${{ matrix.registry }}
+            make docker.push \
+                 tags=${{ steps.version.outputs.group1 }}-$platform \
+                 registries=${{ matrix.registry }}
+          done
+        if: ${{ steps.skip.outputs.no == 'true' }}
+
+      # TODO: create and push docker manifest
+
+      # On GitHub Container Registry README is automatically updated on pushes.
+      - name: Update README on Docker Hub
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          provider: dockerhub
+          destination_container_repo: ${{ github.repository_owner }}/${{ steps.image.outputs.group1 }}
+          readme_file: README.md
+        env:
+          DOCKER_USER: ${{ secrets.DOCKERHUB_BOT_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKERHUB_BOT_PASS }}
+        if: ${{ steps.skip.outputs.no == 'true'
+             && matrix.registry == 'docker.io' }}
+      - name: Update README on Quay.io
+        uses: christian-korneck/update-container-description-action@v1
+        with:
+          provider: quay
+          destination_container_repo: ${{ matrix.registry }}/${{ github.repository_owner }}/${{ steps.image.outputs.group1 }}
+          readme_file: README.md
+        env:
+          DOCKER_APIKEY: ${{ secrets.QUAYIO_API_TOKEN }}
+        if: ${{ steps.skip.outputs.no == 'true'
+             && matrix.registry == 'quay.io' }}
+
+
+
 
 
   #env:
@@ -129,64 +204,7 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
-      - name: Pre-build fresh Docker images cache
-        run: make docker.build.cache no-cache=yes
-
-      - name: Test Docker images
-        run: |
-          # Enable experimental features of Docker Daemon to run multi-arch
-          # images.
-          echo "$(cat /etc/docker/daemon.json)" '{"experimental": true}' \
-          | jq --slurp 'reduce .[] as $item ({}; . * $item)' \
-          | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-
-          make npm.install
-          make test.docker platforms=@all build=yes
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ env.PUBLISH == 'true' }}
-      - name: Login to Quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: instrumentisto+bot
-          password: ${{ secrets.QUAYIO_ROBOT_TOKEN }}
-        if: ${{ env.PUBLISH == 'true' }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: instrumentistobot
-          password: ${{ secrets.DOCKERHUB_BOT_PASS }}
-        if: ${{ env.PUBLISH == 'true' }}
-
       - run: make docker.push
-        if: ${{ env.PUBLISH == 'true' }}
-
-      # On GitHub Container Registry README is automatically updated on pushes.
-      - name: Update README on Quay.io
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_APIKEY: ${{ secrets.QUAYIO_API_TOKEN }}
-        with:
-          provider: quay
-          destination_container_repo: quay.io/instrumentisto/rsync-ssh
-          readme_file: README.md
-        if: ${{ env.PUBLISH == 'true' }}
-      - name: Update README on Docker Hub
-        uses: christian-korneck/update-container-description-action@v1
-        env:
-          DOCKER_USER: instrumentistobot
-          DOCKER_PASS: ${{ secrets.DOCKERHUB_BOT_PASS }}
-        with:
-          provider: dockerhub
-          destination_container_repo: instrumentisto/rsync-ssh
-          readme_file: README.md
         if: ${{ env.PUBLISH == 'true' }}
 
       - name: Parse release version from Git tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: ["master"]
-    tags: ["*"]
+    tags: ["alpine*"]
   pull_request:
     branches: ["master"]
   schedule:
@@ -13,12 +13,104 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  PUBLISH: ${{ github.event_name == 'push'
-               && startsWith(github.ref, 'refs/tags/alpine') }}
-
 jobs:
+
+  ############
+  # Building #
+  ############
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+        os: ["linux"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # for correct image labeling via `git describe --tags`
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+
+      - run: make docker.image no-cache=yes
+                  platform=${{ matrix.os }}/${{ matrix.arch }}
+                  tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
+
+      - run: make docker.tar
+                  to-file=.cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+                  tags=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
+          path: .cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+          retention-days: 1
+
+
+
+
+  ###########
+  # Testing #
+  ###########
+
+  test:
+    needs: ["build"]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
+        os: ["linux"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make npm.install
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_number }}
+          path: .cache/
+      - run: make docker.untar
+                  from-file=.cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
+
+      - run: make test.docker
+                  platforms=${{ matrix.os }}/${{ matrix.arch }}
+                  tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
+
+
+
+
+  #############
+  # Releasing #
+  #############
+
+  publish:
+    needs: ["build", "test"]
+    if: ${{ github.event_name == 'push'
+         && startsWith(github.ref, 'refs/tags/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        registry: ["docker.io", "ghcr.io", "quay.io"]
+    runs-on: ubuntu-latest
+    steps:
+      # Skip if this is fork and no credentials are provided.
+      - id: skip
+        run: echo "no=${{ !(
+               github.repository_owner != 'instrumentisto'
+               && ((matrix.registry == 'quay.io'
+                    && secrets.QUAYIO_ROBOT_USER == '')
+                || (matrix.registry == 'docker.io'
+                    && secrets.DOCKERHUB_BOT_USER == ''))
+             ) }}" >> $GITHUB_OUTPUT
+
+
+
+  #env:
+  #  PUBLISH: ${{ github.event_name == 'push'
+  #    && startsWith(github.ref, 'refs/tags/alpine') }}
+
   buildx:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
 
+      - run: |
+          false
+          true
+
+
       - run: make docker.image no-cache=yes
                   platform=${{ matrix.os }}/${{ matrix.arch }}
                   tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - run: |
-          for i in true false true; do
+          for i in true \
+                   false \
+                   true
+          do
             echo "$i"
             sh -c "$i"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - name: Enable experimental features of Docker Daemon
-        run: |
-          echo "$(cat /etc/docker/daemon.json)" '{"experimental": true}' \
-          | jq --slurp 'reduce .[] as $item ({}; . * $item)' \
-          | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
       - run: make npm.install
 
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
                   from-file=.cache/image-${{ matrix.os }}-${{ matrix.arch }}.tar
 
       - run: make test.docker
-                  platforms=${{ matrix.os }}/${{ matrix.arch }}
+                  platform=${{ matrix.os }}/${{ matrix.arch }}
                   tag=build-${{ github.run_number }}-${{ matrix.os }}-${{ matrix.arch }}
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: docker/setup-buildx-action@v2
 
       - run: |
-          for i in true false; do
+          for i in true false true; do
+            echo "$i"
             sh -c "$i"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: ["master"]
-    #tags: ["alpine*"]
-    tags: ["*"]
+    tags: ["alpine*"]
   pull_request:
     branches: ["master"]
   schedule:
@@ -83,7 +82,7 @@ jobs:
   # Releasing #
   #############
 
-  publish:
+  push:
     needs: ["build", "test"]
     if: ${{ github.event_name == 'push'
          && startsWith(github.ref, 'refs/tags/') }}
@@ -160,8 +159,16 @@ jobs:
                  registries=${{ matrix.registry }}
           done
         if: ${{ steps.skip.outputs.no == 'true' }}
-
-      # TODO: create and push docker manifest
+      - name: Tag and push multi-platform images
+        run: make docker.manifest push=yes
+                  registries=${{ matrix.registry }}
+                  of='${{ steps.version.outputs.group1 }}-linux-amd64
+                      ${{ steps.version.outputs.group1 }}-linux-arm32v6
+                      ${{ steps.version.outputs.group1 }}-linux-arm32v7
+                      ${{ steps.version.outputs.group1 }}-linux-arm64v8
+                      ${{ steps.version.outputs.group1 }}-linux-ppc64le
+                      ${{ steps.version.outputs.group1 }}-linux-s390x'
+        if: ${{ steps.skip.outputs.no == 'true' }}
 
       # On GitHub Container Registry README is automatically updated on pushes.
       - name: Update README on Docker Hub
@@ -186,41 +193,30 @@ jobs:
         if: ${{ steps.skip.outputs.no == 'true'
              && matrix.registry == 'quay.io' }}
 
-
-
-
-
-  #env:
-  #  PUBLISH: ${{ github.event_name == 'push'
-  #    && startsWith(github.ref, 'refs/tags/alpine') }}
-
-  buildx:
-    if: ${{ false }}
+  release-github:
+    name: release on GitHub
+    needs: ["push"]
+    if: ${{ github.event_name == 'push'
+         && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Parse version from Git tag
+        id: version
+        uses: actions-ecosystem/action-regex-match@v2
         with:
-          fetch-depth: 0
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
+          text: ${{ github.ref }}
+          regex: '^refs/tags/(.+)$'
 
-      - run: make docker.push
-        if: ${{ env.PUBLISH == 'true' }}
-
-      - name: Parse release version from Git tag
-        id: release
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-        if: ${{ env.PUBLISH == 'true' }}
       - name: Parse CHANGELOG link
         id: changelog
-        run: echo ::set-output name=LINK::https://github.com/${{ github.repository }}/blob/${{ steps.release.outputs.VERSION }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.release.outputs.VERSION }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)
-        if: ${{ env.PUBLISH == 'true' }}
-      - name: Release on GitHub
+        run: echo "link=${{ github.server_url }}/${{ github.repository }}/blob/${{ steps.version.outputs.group1 }}/CHANGELOG.md#$(sed -n '/^## \[${{ steps.version.outputs.group1 }}\]/{s/^## \[\(.*\)\][^0-9]*\([0-9].*\)/\1--\2/;s/[^0-9a-z-]*//g;p;}' CHANGELOG.md)"
+             >> $GITHUB_OUTPUT
+
+      - name: Create GitHub release
         uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.release.outputs.VERSION }}
+          name: ${{ steps.version.outputs.group1 }}
           body: |
-            [Changelog](${{ steps.changelog.outputs.LINK }})
-        if: ${{ env.PUBLISH == 'true' }}
+            [Changelog](${{ steps.changelog.outputs.link }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
         os: ["linux"]
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,12 +58,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
         os: ["linux"]
+        arch: ["amd64", "arm32v6", "arm32v7", "arm64v8", "ppc64le", "s390x"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - run: make npm.install
+
+      - name: Enable experimental features of Docker Daemon
+        run: |
+          echo "$(cat /etc/docker/daemon.json)" '{"experimental": true}' \
+          | jq --slurp 'reduce .[] as $item ({}; . * $item)' \
+          | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: make npm.install
-
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
       - name: Enable experimental features of Docker Daemon
         run: |
           echo "$(cat /etc/docker/daemon.json)" '{"experimental": true}' \
           | jq --slurp 'reduce .[] as $item ({}; . * $item)' \
           | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
+      - run: make npm.install
 
       - uses: actions/download-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /*.iml
 .DS_Store
 
+/.cache/
 /node_modules/
 /package-lock.json
 /yarn.lock

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ endif
 	PLATFORM=$(or $(call dockerify,$(platform)),linux/amd64) \
 	node_modules/.bin/bats \
 		--timing $(if $(call eq,$(CI),),--pretty,--formatter tap) \
+		--print-output-on-failure \
 		tests/main.bats
 
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ comma := ,
 eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
                                 $(findstring $(2),$(1))),1)
 
+# Maps platform identifier to the one accepted by Docker CLI.
+dockerify = $(strip $(if $(call eq,$(1),linux/arm32v6),linux/arm/v6,\
+                    $(if $(call eq,$(1),linux/arm32v7),linux/arm/v7,\
+                    $(if $(call eq,$(1),linux/arm64v8),linux/arm64/v8,\
+                                                       $(platform)))))
+
 
 
 
@@ -20,22 +26,16 @@ ALPINE_VER ?= $(strip \
 BUILD_REV ?= $(strip \
 	$(shell grep 'ARG build_rev=' Dockerfile | cut -d '=' -f2))
 
-NAMESPACES := instrumentisto \
-              ghcr.io/instrumentisto \
-              quay.io/instrumentisto
 NAME := rsync-ssh
+OWNER := $(or $(GITHUB_REPOSITORY_OWNER),instrumentisto)
+REGISTRIES := $(strip $(subst $(comma), ,\
+	$(shell grep -m1 'registry: \["' .github/workflows/ci.yml \
+	        | cut -d':' -f2 | tr -d '"][')))
 TAGS ?= alpine$(ALPINE_VER)-r$(BUILD_REV) \
         alpine$(ALPINE_VER) \
         alpine \
         latest
 VERSION ?= $(word 1,$(subst $(comma), ,$(TAGS)))
-PLATFORMS ?= linux/amd64 \
-             linux/arm64 \
-             linux/arm/v6 \
-             linux/arm/v7 \
-             linux/ppc64le \
-             linux/s390x
-MAIN_PLATFORM ?= $(word 1,$(subst $(comma), ,$(PLATFORMS)))
 
 
 
@@ -59,10 +59,14 @@ test: test.docker
 # Docker commands #
 ###################
 
-docker-namespaces = $(strip $(if $(call eq,$(namespaces),),\
-                            $(NAMESPACES),$(subst $(comma), ,$(namespaces))))
+docker-registries = $(strip $(if $(call eq,$(registries),),\
+                            $(REGISTRIES),$(subst $(comma), ,$(registries))))
 docker-tags = $(strip $(if $(call eq,$(tags),),\
                       $(TAGS),$(subst $(comma), ,$(tags))))
+
+
+docker-namespaces = $(strip $(if $(call eq,$(namespaces),),\
+                            $(NAMESPACES),$(subst $(comma), ,$(namespaces))))
 docker-platforms = $(strip $(if $(call eq,$(platforms),),\
                            $(PLATFORMS),$(subst $(comma), ,$(platforms))))
 
@@ -91,45 +95,29 @@ define docker.buildx
 endef
 
 
-# Pre-build cache for Docker image builds.
-#
-# WARNING: This command doesn't apply tag to the built Docker image, just
-#          creates a build cache. To produce a Docker image with a tag, use
-#          `docker.tag` command right after running this one.
+# Build Docker image with the given tag.
 #
 # Usage:
-#	make docker.build.cache
-#		[platforms=($(PLATFORMS)|<platform-1>[,<platform-2>...])]
-#		[no-cache=(no|yes)]
-#		[ALPINE_VER=<alpine-version>]
-#		[BUILD_REV=<build-revision>]
+#	make docker.image [tag=($(VERSION)|<docker-tag>)]] [no-cache=(no|yes)]
+#	                  [platform=<os>/<arch>]
+#	                  [ALPINE_VER=<alpine-version>]
+#	                  [BUILD_REV=<build-revision>]
 
-docker.build.cache:
-	$(call docker.buildx,\
-		instrumentisto,\
-		build-cache,\
-		$(shell echo "$(docker-platforms)" | tr -s '[:blank:]' ','),\
-		$(no-cache),\
-		--output 'type=image$(comma)push=false')
-
-
-# Build Docker image on the given platform with the given tag.
-#
-# Usage:
-#	make docker.image
-#		[tag=($(VERSION)|<tag>)]
-#		[platform=($(MAIN_PLATFORM)|<platform>)]
-#		[no-cache=(no|yes)]
-#		[ALPINE_VER=<alpine-version>]
-#		[BUILD_REV=<build-revision>]
+github_url := $(strip $(or $(GITHUB_SERVER_URL),https://github.com))
+github_repo := $(strip $(or $(GITHUB_REPOSITORY),$(OWNER)/$(NAME)-docker-image))
 
 docker.image:
-	$(call docker.buildx,\
-		instrumentisto,\
-		$(if $(call eq,$(tag),),$(VERSION),$(tag)),\
-		$(if $(call eq,$(platform),),$(MAIN_PLATFORM),$(platform)),\
-		$(no-cache),\
-		--load)
+	docker buildx build --force-rm \
+		$(if $(call eq,$(platform),),,--platform $(call dockerify,$(platform)))\
+		$(if $(call eq,$(no-cache),yes),--no-cache --pull,) \
+		--build-arg alpine_ver=$(ALPINE_VER) \
+		--build-arg build_rev=$(BUILD_REV) \
+		--label org.opencontainers.image.source=$(github_url)/$(github_repo) \
+		--label org.opencontainers.image.revision=$(strip \
+			$(shell git show --pretty=format:%H --no-patch)) \
+		--label org.opencontainers.image.version=$(strip \
+			$(shell git describe --tags --dirty)) \
+		--load -t $(OWNER)/$(NAME):$(or $(tag),$(VERSION)) ./
 
 
 # Push Docker images to their repositories (container registries),
@@ -153,6 +141,33 @@ docker.push:
 				--push)))
 
 
+# Save Docker images to a tarball file.
+#
+# Usage:
+#	make docker.tar [to-file=(.cache/image.tar|<file-path>)]
+#	                [tags=($(VERSION)|<docker-tag-1>[,<docker-tag-2>...])]
+
+docker-tar-file = $(or $(to-file),.cache/image.tar)
+
+docker.tar:
+	@mkdir -p $(dir $(docker-tar-file))
+	docker save -o $(docker-tar-file) \
+		$(foreach tag,$(subst $(comma), ,$(or $(tags),$(VERSION))),\
+			$(OWNER)/$(NAME):$(tag))
+
+
+docker.test: test.docker
+
+
+# Load Docker images from a tarball file.
+#
+# Usage:
+#	make docker.untar [from-file=(.cache/image.tar|<file-path>)]
+
+docker.untar:
+	docker load -i $(or $(from-file),.cache/image.tar)
+
+
 
 
 ####################
@@ -165,37 +180,18 @@ docker.push:
 #	https://github.com/bats-core/bats-core
 #
 # Usage:
-#	make test.docker
-#		[tag=($(VERSION)|<tag>)]
-#		[platforms=($(MAIN_PLATFORM)|@all|<platform-1>[,<platform-2>...])]
-#		[( [build=no]
-#		 | build=yes [HARAKA_VER=<haraka-version>]
-#		             [NODE_VER=<node-version>]
-#		             [BUILD_REV=<build-revision>] )]
+#	make test.docker [tag=($(VERSION)|<docker-tag>)]
+#	                 [platform=(linux/amd64|<os>/<arch>)]
 
-test-docker-platforms = $(strip $(if $(call eq,$(platforms),),$(MAIN_PLATFORM),\
-                                $(if $(call eq,$(platforms),@all),$(PLATFORMS),\
-                                $(docker-platforms))))
 test.docker:
 ifeq ($(wildcard node_modules/.bin/bats),)
 	@make npm.install
 endif
-	$(foreach platform,$(test-docker-platforms),\
-		$(call test.docker.do,\
-			$(if $(call eq,$(tag),),$(VERSION),$(tag)),\
-			$(platform)))
-define test.docker.do
-	$(eval tag := $(strip $(1)))
-	$(eval platform := $(strip $(2)))
-	$(if $(call eq,$(build),yes),\
-		@make docker.image no-cache=no tag=$(tag) platform=$(platform) \
-			ALPINE_VER=$(ALPINE_VER) \
-			BUILD_REV=$(BUILD_REV) ,)
-	IMAGE=instrumentisto/$(NAME):$(tag) PLATFORM=$(platform) \
+	IMAGE=$(OWNER)/$(NAME):$(or $(tag),$(VERSION)) \
+	PLATFORM=$(or $(call dockerify,$(platform)),linux/amd64) \
 	node_modules/.bin/bats \
 		--timing $(if $(call eq,$(CI),),--pretty,--formatter tap) \
 		tests/main.bats
-endef
 
 
 
@@ -247,7 +243,7 @@ endif
 ##################
 
 .PHONY: image push release test \
-        docker.build.cache docker.image docker.push \
+        docker.image docker.push docker.tar docker.test docker.untar \
         git.release \
         npm.install \
         test.docker

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Rsync + SSH Docker image
 
 
 
+## Supported platforms
+
+- `linux`: `amd64`, `arm32v6`, `arm32v7`, `arm64v8`, `ppc64le`, `s390x`
+
+
+
+
 ## What is Rsync and SSH?
 
 SSH (Secure Shell) is a cryptographic network protocol for operating network services securely over an unsecured network. The best known example application is for remote login to computer systems by users.
@@ -66,6 +73,45 @@ docker run --rm -i -v <local-dest-path>:/mnt instrumentisto/rsync-ssh \
 
 
 
+## Image versions
+
+
+### `alpine`
+
+Latest tag of the latest [Alpine][1] version.
+
+This image is based on the popular [Alpine Linux project][1], available in [the alpine official image][2]. [Alpine Linux][1] is much smaller than most distribution base images (~5MB), and thus leads to much slimmer images in general.
+
+This is a multi-platform image.
+
+
+### `alpine<X.Y>`
+
+Latest tag of the latest minor `X.Y` [Alpine][1] version.
+
+This is a multi-platform image.
+
+
+### `alpine<X.Y>-r<N>`
+
+Concrete `N` image revision tag of the concrete minor `X.Y` [Alpine][1] version.
+
+Once build, it's never updated.
+
+This is a multi-platform image.
+
+
+### `alpine<X.Y>-r<N>-<os>-<arch>`
+
+Concrete `N` image revision tag of the concrete minor `X.Y` [Alpine][1] version on the concrete `os` and `arch`.
+
+Once build, it's never updated.
+
+This is a single-platform image.
+
+
+
+
 ## License
 
 Rsync is licensed under [GNU GPL version 3 license][93].  
@@ -89,8 +135,10 @@ If you have any problems with or questions about this image, please contact us t
 
 
 
-
 [DockerHub]: https://hub.docker.com
+
+[1]: http://alpinelinux.org
+[2]: https://hub.docker.com/_/alpine
 
 [10]: https://github.com/instrumentisto/rsync-ssh-docker-image/issues
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "bats": "^1.1"
+    "bats": "^1.8"
   }
 }

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -8,12 +8,12 @@
   [ "$status" -eq 0 ]
   if [ "$PLATFORM" = "linux/amd64" ]; then
     [ "$output" = "x86_64" ]
-  elif [ "$PLATFORM" = "linux/arm64/v8" ]; then
-    [ "$output" = "aarch64" ]
   elif [ "$PLATFORM" = "linux/arm/v6" ]; then
     [ "$output" = "armv7l" ]
   elif [ "$PLATFORM" = "linux/arm/v7" ]; then
     [ "$output" = "armv7l" ]
+  elif [ "$PLATFORM" = "linux/arm64/v8" ]; then
+    [ "$output" = "aarch64" ]
   else
     [ "$output" = "$(echo $PLATFORM | cut -d '/' -f2-)" ]
   fi

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -2,12 +2,13 @@
 
 
 @test "Built on correct arch" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'uname -m'
   [ "$status" -eq 0 ]
   if [ "$PLATFORM" = "linux/amd64" ]; then
     [ "$output" = "x86_64" ]
-  elif [ "$PLATFORM" = "linux/arm64" ]; then
+  elif [ "$PLATFORM" = "linux/arm64/v8" ]; then
     [ "$output" = "aarch64" ]
   elif [ "$PLATFORM" = "linux/arm/v6" ]; then
     [ "$output" = "armv7l" ]
@@ -20,20 +21,23 @@
 
 
 @test "SSH is installed" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'which ssh'
   [ "$status" -eq 0 ]
 }
 
 
 @test "rsync is installed" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'which rsync'
   [ "$status" -eq 0 ]
 }
 
 @test "rsync runs ok" {
-  run docker run --rm --platform $PLATFORM --entrypoint sh $IMAGE -c \
+  run docker run --rm --pull never --platform $PLATFORM \
+                 --entrypoint sh $IMAGE -c \
     'rsync --help'
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
This is a third attempt to make CI pipeline for building multi-arch images granular, as it already is for single-arch image repos.